### PR TITLE
Fix minor typo in fio2.sh

### DIFF
--- a/scripts/disk/fio2.sh
+++ b/scripts/disk/fio2.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-fio --directory=/tmp --name fio_test_file --direct=1 --rw=randread --bs=16k --size=100M --numjobs=16 --time_based --runtime=180 --group_reporting
---norandommap
+fio --directory=/tmp --name fio_test_file --direct=1 --rw=randread --bs=16k --size=100M --numjobs=16 --time_based --runtime=180 --group_reporting --norandommap


### PR DESCRIPTION
This commit fixes the misplaced `--norandommap` fio flag.